### PR TITLE
wip: Initial config/training script structure

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,94 @@
+
+
+## Config Structure
+
+Current hypothetical config folder structure is as follows:
+```
+├── configs
+    ├── callbacks
+        ├── default.yaml
+    ├── dataset
+        ├── sequence.yaml 
+    ├── logger
+        ├── wandb.yaml
+    ├── model
+        ├── unet.yaml
+        ├── unet_conditional.yaml
+        ├── unet_bitdiffusion.yaml
+    ├── paths
+        ├── default.yaml
+    ├── train.yaml
+```
+
+As new items (models, datasets, etc.) are added, a corresponding config file can be included so that minimal parameter altering is needed across various experiments
+
+## How to Run
+Below contains the main training config file that can be altered to fit any training alterations that are desired.
+Every parameter listed under defaults is defined within a config listed above.
+
+<details>
+<summary><b>Training config</b></summary>
+
+```yaml
+defaults:
+  - model: unet_conditional
+  - dataset: sequence
+  - logger: wandb
+  - callbacks: default
+
+ckpt: null # path to checkpoint
+seed: 42
+batch_size: 32
+devices: gpu
+benchmark: True
+ckpt_dir: # path still to be defined 
+accelerator: gpu
+strategy: ddp
+min_epochs: 5
+max_epochs: 100000
+gradient_clip_val: 1.0
+accumulate_grad_batches: 1
+log_every_n_steps: 1
+check_val_every_n_epoch: 1 #for debug purposes
+save_last: True
+precision: 32
+```
+</details>
+
+### Using hydra config in a Jupyter Notebook
+
+Including the following at the beginning of a jupyter notebook will initialize hydra, load defined training config, and then print it.
+
+```python
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+
+initialize(version_base=None, config_path="./src/configs")
+cfg = compose(config_name="train")
+print(OmegaConf.to_yaml(cfg))
+```
+
+When initializing hydra it is possible to override any of the default assignments. 
+Here is an example of overriding batch_size and seed while initializing hydra:
+
+```python
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+
+initialize(version_base=None, config_path="./src/configs")
+cfg = compose(overrides=["batch_size=64", "seed=1"])
+print(OmegaConf.to_yaml(cfg))
+```
+
+The following link to hydra documentation provides more information on override syntax: <br/>
+https://hydra.cc/docs/advanced/override_grammar/basic/ <br/>
+
+For more information regarding hydra initialization in jupyter see the following link:
+https://github.com/facebookresearch/hydra/blob/main/examples/jupyter_notebooks/compose_configs_in_notebook.ipynb
+
+## Still To Do:
+* Alter training script to accommodate all logs we wish to track using wandb
+* Decide on default hyperparameters in train.yaml
+* Further alter config folder structure to best suit our training and testing practices
+* Define default paths for dataset within path config file so that directory can be referenced across various other configs
+* Hydra config logs currently output in src directory, creating the following folder structure ./src/outputs/YYYY-MM-DD/MM-HH-SS. If we wish to alter this it can be done in a hydra config file.

--- a/src/configs/callbacks/default.yaml
+++ b/src/configs/callbacks/default.yaml
@@ -1,0 +1,12 @@
+save_checkpoint:
+  target: pytorch_lightning.callbacks.ModelCheckpoint
+  params:
+    path: # to be entered
+    monitor: val_loss
+    mode: min
+    save_top_k: 10
+    save_last: True
+learning_rate:
+  target: pytorch_lightning.callbacks.LearningRateMonitor
+  params:
+    logging_interval: epoch

--- a/src/configs/dataset/sequence.yaml
+++ b/src/configs/dataset/sequence.yaml
@@ -1,0 +1,15 @@
+train_dl:
+  _target_: src.data.sequence_dataloader.SequenceDataModule
+  train_path: # add training dataset path
+  batch_size: 32
+  num_workers: 4
+ # transform:
+  #  _target_: # directly reference transforms -> torchvision.transforms.ToTensor
+
+val_dl:
+  _target_: src.data.sequence_dataloader.SequenceDataModule
+  val_path: # add validation dataset path
+  batch_size: 32
+  num_workers: 4
+  #transform:
+  #  _target_: # directly reference transforms -> torchvision.transforms.ToTensor

--- a/src/configs/logger/wandb.yaml
+++ b/src/configs/logger/wandb.yaml
@@ -1,0 +1,5 @@
+wandb:
+  _target_: pytorch_lightning.loggers.wandb.WandbLogger
+  save_dir: ""
+  project: ""
+  log_model: False

--- a/src/configs/model/unet_conditional.yaml
+++ b/src/configs/model/unet_conditional.yaml
@@ -1,0 +1,30 @@
+model:
+  _target_: src.models.diffusion.ddpm
+  params:
+    beta_end: 0.05
+    schedule: linear
+    timestep: 1000
+    is_conditional: True
+    criterion: utils.metrics.MetricName
+    use_ema: True
+    lr_warmup: 5000
+    lr_scheduler_config:
+      _target_: torch.optim.lr_scheduler.MultiStepLR
+      params:
+        milestones: [5, 10, 20]
+        gamma: 0.1
+
+    optimizer_config:
+      target: torch.optim.Adam
+      params:
+        lr: 1e-4
+
+    unet_config:
+      target: models.networks.unet_lucas
+      params:
+        dim: 200
+        init_dim: None
+        dim_mult: [1, 2, 4]
+        channels: 1
+        resnet_block_groups: 8
+        learned_sinusoidal_dim: 16

--- a/src/configs/paths/default.yaml
+++ b/src/configs/paths/default.yaml
@@ -1,0 +1,2 @@
+
+root: ${hydra:runtime.cwd}/

--- a/src/configs/template_config.yaml
+++ b/src/configs/template_config.yaml
@@ -1,3 +1,6 @@
+ckpt: null # path to checkpoint
+seed: 42
+
 model:
   target: models.diffusion.DDPM
   params:
@@ -29,17 +32,28 @@ model:
         resnet_block_groups: 8
         learned_sinusoidal_dim: 16
 
-data:
-  target: data.celeba.CelebADataModule
-  params:
-    batch_size: 2048
-    num_workers: 4
+train_dl:
+  _target_: src.data.sequence_dataloader.SequenceDataModule
+  train_path: # add training dataset path
+  batch_size: 32
+  num_workers: 4
+  transform:
+    _target_: # directly reference transforms -> torchvision.transforms.ToTensor
+
+val_dl:
+  _target_: src.data.sequence_dataloader.SequenceDataModule
+  val_path: # add validation dataset path
+  batch_size: 32
+  num_workers: 4
+  transform:
+    _target_: # directly reference transforms -> torchvision.transforms.ToTensor
 
 lightning:
   callbacks:
     save_checkpoint:
       target: pytorch_lightning.callbacks.ModelCheckpoint
       params:
+        path: ""
         monitor: val_loss
         mode: min
         save_top_k: 10
@@ -51,6 +65,7 @@ lightning:
 
   trainer:
     benchmark: True
+    ckpt_dir:
     accelerator: gpu
     strategy: ddp
     min_epochs: 5
@@ -61,3 +76,7 @@ lightning:
     check_val_every_n_epoch: 1 #for debug purposes
     save_last: True
     precision: 32
+
+  hydra:
+    run:
+      dir:

--- a/src/configs/train.yaml
+++ b/src/configs/train.yaml
@@ -1,0 +1,22 @@
+defaults:
+  - model: unet_conditional
+  - dataset: sequence
+  - logger: wandb
+  - callbacks: default
+
+ckpt: null # path to checkpoint
+seed: 42
+batch_size: 32
+devices: gpu
+benchmark: True
+ckpt_dir: null
+accelerator: gpu
+strategy: ddp
+min_epochs: 5
+max_epochs: 100000
+gradient_clip_val: 1.0
+accumulate_grad_batches: 1
+log_every_n_steps: 1
+check_val_every_n_epoch: 1 #for debug purposes
+save_last: True
+precision: 32

--- a/src/train.py
+++ b/src/train.py
@@ -5,36 +5,34 @@ import wandb
 
 from omegaconf import DictConfig, OmegaConf
 from hydra.utils import instantiate
-from pytorch_lightning.loggers import WandbLogger
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
-@hydra.main(config_path="configs", config_name="template_config")
+@hydra.main(config_path="configs", config_name="train")
 def train(cfg: DictConfig):
     # Keeping track of current config settings in logger
     logger.info(f"Training with config:\n{OmegaConf.to_yaml(cfg)}")
-    run = wandb.init(project="", config=cfg, group="train")
-    pl_logger = WandbLogger()  # include in config?
-    local_logger = instantiate(cfg.logger)
+    run = wandb.init(project=cfg.logger.wandb.project, config=cfg)
+
+    # Placeholder for what loss or metric values we plan to track with wandb
+    wandb.log({"loss": loss})
 
     pl.seed_everything(cfg.seed)
 
     # Check if this works
-    scheduler = instantiate(cfg.scheduler)
-    model = instantiate(cfg.model, variance_schedule=scheduler)
-    train_dl = instantiate(cfg.train)
-    val_dl = instantiate(cfg.val)
+    model = instantiate(cfg.model)
+    train_dl = instantiate(cfg.dataset.train_dl)
+    val_dl = instantiate(cfg.dataset.val_dl)
 
     if cfg.ckpt:
-        ckpt_path = cfg.ckpt
-        model.load_from_checkpoint(ckpt_path)
+        model.load_from_checkpoint(cfg.ckpt)
 
     trainer = pl.Trainer(
         callbacks=cfg.callbacks,
         accelerator=cfg.accelerator,
         devices=cfg.devices,
-        logger=pl_logger
+        logger=cfg.logger.wandb
     )
 
     trainer.fit(model, train_dl, val_dl)

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,44 @@
+import hydra
+import pytorch_lightning as pl
+import logging
+import wandb
+
+from omegaconf import DictConfig, OmegaConf
+from hydra.utils import instantiate
+from pytorch_lightning.loggers import WandbLogger
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main(config_path="configs", config_name="template_config")
+def train(cfg: DictConfig):
+    # Keeping track of current config settings in logger
+    logger.info(f"Training with config:\n{OmegaConf.to_yaml(cfg)}")
+    run = wandb.init(project="", config=cfg, group="train")
+    pl_logger = WandbLogger()  # include in config?
+    local_logger = instantiate(cfg.logger)
+
+    pl.seed_everything(cfg.seed)
+
+    # Check if this works
+    scheduler = instantiate(cfg.scheduler)
+    model = instantiate(cfg.model, variance_schedule=scheduler)
+    train_dl = instantiate(cfg.train)
+    val_dl = instantiate(cfg.val)
+
+    if cfg.ckpt:
+        ckpt_path = cfg.ckpt
+        model.load_from_checkpoint(ckpt_path)
+
+    trainer = pl.Trainer(
+        callbacks=cfg.callbacks,
+        accelerator=cfg.accelerator,
+        devices=cfg.devices,
+        logger=pl_logger
+    )
+
+    trainer.fit(model, train_dl, val_dl)
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
The readme covers most of my thought process regarding how configs folders could be organized. It takes our template_config file into separate files to make it more readable and then introduces some new config files for recent project additions. I have included some to do items at the bottom of the readme. I anticipate the structure will undergo several changes in the future, but I hope this provides a good framework moving forward. 