### PR TITLE
Dataloader tests + additional sequence encoding methods

### DIFF
--- a/src/data/sequence_dataloader.py
+++ b/src/data/sequence_dataloader.py
@@ -8,11 +8,15 @@ import pytorch_lightning as pl
 from torch.utils.data import Dataset, DataLoader 
 
 class SequenceDatasetBase(Dataset):
-    def __init__(self, data_path, sequence_length=200, transform=None):
+    def __init__(self, data_path, sequence_length=200, sequence_encoding="polar", sequence_transform=None, cell_type_transform=None):
         super().__init__()
         self.data = pd.read_csv(data_path, sep="\t")
         self.sequence_length = sequence_length
-        self.transform = transform
+        self.sequence_encoding = sequence_encoding
+        self.sequence_transform = sequence_transform
+        self.cell_type_transform = cell_type_transform
+        self.alphabet = ["A", "C", "T", "G"]
+        self.check_data_validity()
 
     def __len__(self):
         return len(self.data)
@@ -21,28 +25,49 @@ class SequenceDatasetBase(Dataset):
         # Iterating through DNA sequences from dataset and one-hot encoding all nucleotides
         current_seq = self.data["raw_sequence"][index]
         if 'N' not in current_seq: 
-            X_seq = np.array(self.one_hot_encode(current_seq, ['A','C','T','G'], self.sequence_length))
-            X_seq = X_seq.T
-            X_seq[X_seq == 0] = -1
+            X_seq = self.encode_sequence(current_seq, encoding=self.sequence_encoding)
             
             # Reading cell component at current index
             X_cell_type = self.data["component"][index]
             
-            if self.transform:
-                X_seq = self.transform(X_seq)
-                X_cell_type = self.transform(X_cell_type)
+            if self.sequence_transform is not None:
+                X_seq = self.sequence_transform(X_seq)
+            if self.cell_type_transform is not None:
+                X_cell_type = self.cell_type_transform(X_cell_type)
 
             return X_seq, X_cell_type
 
-    # Function for one hot encoding each line of the sequence dataset
-    def one_hot_encode(self, seq, alphabet, sequence_length):
+    def check_data_validity(self):
         """
-        One-hot encoding a sequence 
+        Checks if the data is valid.
+        """
+        if not set("".join(self.data["raw_sequence"])).issubset(set(self.alphabet)):
+            raise ValueError(f"Sequence contains invalid characters.")
+
+    def encode_sequence(self, seq, encoding):
+        """
+        Encodes a sequence using the given encoding scheme ("polar", "onehot", "ordinal").
+        """
+        if encoding == "polar":
+            seq = self.one_hot_encode(seq).T
+            seq[seq == 0] = -1
+        elif encoding == "onehot":
+            seq = self.one_hot_encode(seq).T
+        elif encoding == "ordinal":
+            seq = np.array([self.alphabet.index(n) for n in seq])
+        else:
+            raise ValueError(f"Unknown encoding scheme: {encoding}")
+        return seq
+
+    # Function for one hot encoding each line of the sequence dataset
+    def one_hot_encode(self, seq):
+        """
+        One-hot encoding a sequence
         """
         seq_len = len(seq)
-        seq_array = np.zeros((sequence_length, len(alphabet)))
+        seq_array = np.zeros((self.sequence_length, len(self.alphabet)))
         for i in range(seq_len):
-            seq_array[i, alphabet.index(seq[i])] = 1 
+            seq_array[i, self.alphabet.index(seq[i])] = 1
         return seq_array
 
 
@@ -60,7 +85,18 @@ class SequenceDatasetTest(SequenceDatasetBase):
 
 
 class SequenceDataModule(pl.LightningDataModule):
-    def __init__(self, train_path=None, val_path=None, test_path=None, transform=None, batch_size=None, num_workers=None):
+    def __init__(
+        self,
+        train_path=None,
+        val_path=None,
+        test_path=None,
+        sequence_length=200,
+        sequence_encoding="polar",
+        sequence_transform=None,
+        cell_type_transform=None,
+        batch_size=None,
+        num_workers=1
+    ):
         super().__init__()
         self.datasets = dict()
         self.train_dataloader, self.val_dataloader, self.test_dataloader = None, None, None
@@ -77,14 +113,38 @@ class SequenceDataModule(pl.LightningDataModule):
             self.datasets["test"] = test_path
             self.test_dataloader = self._test_dataloader
 
-        self.transform = transform
+        self.sequence_length = sequence_length
+        self.sequence_encoding = sequence_encoding
+        self.sequence_transform = sequence_transform
+        self.cell_type_transform = cell_type_transform
         self.batch_size = batch_size
         self.num_workers = num_workers
 
     def setup(self):
-       self.train_data = SequenceDatasetTrain(self.datasets["train"], transform = self.transform)
-       self.val_data = SequenceDatasetValidation(self.datasets["validation"], transform = self.transform)
-       self.test_data = SequenceDatasetTest(self.datasets["test"], transform = self.transform)
+        if "train" in self.datasets:
+            self.train_data = SequenceDatasetTrain(
+                data_path=self.datasets["train"],
+                sequence_length=self.sequence_length,
+                sequence_encoding=self.sequence_encoding,
+                sequence_transform=self.sequence_transform,
+                cell_type_transform=self.cell_type_transform
+            )
+        if "validation" in self.datasets:
+            self.val_data = SequenceDatasetValidation(
+                data_path=self.datasets["validation"],
+                sequence_length=self.sequence_length,
+                sequence_encoding=self.sequence_encoding,
+                sequence_transform=self.sequence_transform,
+                cell_type_transform=self.cell_type_transform
+            )
+        if "test" in self.datasets:
+            self.test_data = SequenceDatasetTest(
+                data_path=self.datasets["test"],
+                sequence_length=self.sequence_length,
+                sequence_encoding=self.sequence_encoding,
+                sequence_transform=self.sequence_transform,
+                cell_type_transform=self.cell_type_transform
+            )
 
     def _train_dataloader(self):
         return DataLoader(self.train_data,

--- a/src/data/sequence_dataloader.py
+++ b/src/data/sequence_dataloader.py
@@ -44,6 +44,10 @@ class SequenceDatasetBase(Dataset):
         if not set("".join(self.data["raw_sequence"])).issubset(set(self.alphabet)):
             raise ValueError(f"Sequence contains invalid characters.")
 
+        uniq_raw_seq_len = self.data["raw_sequence"].str.len().unique()
+        if len(uniq_raw_seq_len) != 1 or uniq_raw_seq_len[0] != self.sequence_length:
+            raise ValueError(f"The sequence length does not match the data.")
+
     def encode_sequence(self, seq, encoding):
         """
         Encodes a sequence using the given encoding scheme ("polar", "onehot", "ordinal").

--- a/src/data/sequence_dataloader.py
+++ b/src/data/sequence_dataloader.py
@@ -47,22 +47,23 @@ class SequenceDatasetBase(Dataset):
 
 
 class SequenceDatasetTrain(SequenceDatasetBase):
-    def __init__(self, **kwargs):
-        super().__init__(data_path="", **kwargs)
+    def __init__(self, data_path="", **kwargs):
+        super().__init__(data_path=data_path, **kwargs)
 
 class SequenceDatasetValidation(SequenceDatasetBase):
-    def __init__(self, **kwargs):
-        super().__init__(data_path="", **kwargs)
+    def __init__(self, data_path="", **kwargs):
+        super().__init__(data_path=data_path, **kwargs)
 
 class SequenceDatasetTest(SequenceDatasetBase):
-    def __init__(self, **kwargs):
-        super().__init__(data_path="", **kwargs)
+    def __init__(self, data_path="", **kwargs):
+        super().__init__(data_path=data_path, **kwargs)
 
 
 class SequenceDataModule(pl.LightningDataModule):
     def __init__(self, train_path=None, val_path=None, test_path=None, transform=None, batch_size=None, num_workers=None):
         super().__init__()
         self.datasets = dict()
+        self.train_dataloader, self.val_dataloader, self.test_dataloader = None, None, None
 
         if train_path:
             self.datasets["train"] = train_path

--- a/tests/data/test_sequence_dataloader.py
+++ b/tests/data/test_sequence_dataloader.py
@@ -1,0 +1,318 @@
+import os
+import pandas as pd
+from src.data.sequence_dataloader import SequenceDataModule
+
+
+def prepare_dummy_data(path):
+    """Prepares dummy data for testing."""
+    pd.DataFrame({
+        "raw_sequence": ["ATCGATCGATCG", "GGTGAACGATTA", "AATCGTATCGCG", "CTTATCGATCCG"],
+        "component": [1, 2, 1, 10],
+    }).to_csv(path, index=False, sep="\t")
+
+def test_invalid_data():
+    # prepare invalid data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    pd.DataFrame({
+        "raw_sequence": ["ZCCCACTGACTG", "ACTGACTGACTG", "AAAACCCCTTTT", "ABCDEFGHIJKL"],
+        "component": [1, 2, 1, 10],
+    }).to_csv(dummy_data_path, index=False, sep="\t")
+
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="polar",
+        batch_size=2,
+        num_workers=1,
+    )
+    # check that invalid data is detected
+    try:
+        datamodule.setup()
+        assert False, "Invalid data should have been detected."
+    except ValueError:
+        pass
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_train_val_test_data_split():
+    # prepare dummy data
+    dummy_train_data_path = "_tmp_seq_dataloader_train_data.csv"
+    dummy_val_data_path = "_tmp_seq_dataloader_val_data.csv"
+    dummy_test_data_path = "_tmp_seq_dataloader_test_data.csv"
+    pd.DataFrame({
+        "raw_sequence": ["AAAAAAAAAA", "AAAAAAAAAA", "AAAAAAAAAA", "AAAAAAAAAA"],
+        "component": [0, 0, 0, 0],
+    }).to_csv(dummy_train_data_path, index=False, sep="\t")
+    pd.DataFrame({
+        "raw_sequence": ["CCCCCCCCCC", "CCCCCCCCCC", "CCCCCCCCCC", "CCCCCCCCCC"],
+        "component": [1, 1, 1, 1],
+    }).to_csv(dummy_val_data_path, index=False, sep="\t")
+    pd.DataFrame({
+        "raw_sequence": ["TTTTTTTTTT", "TTTTTTTTTT", "TTTTTTTTTT", "TTTTTTTTTT"],
+        "component": [2, 2, 2, 2],
+    }).to_csv(dummy_test_data_path, index=False, sep="\t")
+
+    # check loading of only a single data set
+    datamodule = SequenceDataModule(
+        train_path=None,
+        val_path=dummy_val_data_path,
+        test_path=None,
+        sequence_length=10
+    )
+    datamodule.setup()
+    assert datamodule.train_dataloader is None
+    assert len(datamodule.val_data) == 4
+    assert datamodule.test_dataloader is None
+
+    # check differences between train, val, and test data
+    datamodule = SequenceDataModule(
+        train_path=dummy_train_data_path,
+        val_path=dummy_val_data_path,
+        test_path=dummy_test_data_path,
+        sequence_length=10,
+        sequence_encoding="polar",
+        batch_size=3,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    assert len(datamodule.train_dataloader()) == 2
+    assert len(datamodule.val_dataloader()) == 2
+    assert len(datamodule.test_dataloader()) == 2
+    seen_nucleotide_idxs = set()
+    for dl_idx, dataloader in enumerate([datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]):
+        dataloader_iter = iter(dataloader)
+        # first batch
+        batch = next(dataloader_iter)
+        assert batch[0].shape == (3, 4, 10)
+        assert batch[1].shape == (3,)
+        uniq_nucleotides = batch[0].max(dim=1).indices.unique().tolist()
+        seen_nucleotide_idxs.update(uniq_nucleotides)
+        assert len(uniq_nucleotides) == 1
+        assert (batch[1] == dl_idx).all()
+        # second batch
+        batch = next(dataloader_iter)
+        assert batch[0].shape == (1, 4, 10)
+        assert batch[1].shape == (1,)
+        assert batch[0].max(dim=1).indices.unique().tolist() == uniq_nucleotides
+        assert (batch[1] == dl_idx).all()
+
+    # remove dummy data
+    for path in [dummy_train_data_path, dummy_val_data_path, dummy_test_data_path]:
+        os.remove(path)
+
+def test_polar_encoding():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="polar",
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        for batch in dataloader:
+            assert batch[0].shape == (2, 4, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 1).all()
+            assert (batch[0].min(dim=1).values == -1).all()
+            assert (batch[0].prod(dim=1) == -1).all()
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_onehot_encoding():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="onehot",
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        for batch in dataloader:
+            assert batch[0].shape == (2, 4, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 1).all()
+            assert (batch[0].min(dim=1).values == 0).all()
+            assert (batch[0].sum(dim=1) == 1).all()
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_ordinal_encoding():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="ordinal",
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        for batch in dataloader:
+            assert batch[0].shape == (2, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 3).all()
+            assert (batch[0].min(dim=1).values == 0).all()
+            assert set(batch[0].tolist()[0]) == set([0, 1, 2, 3])
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_polar_transforms():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="polar",
+        sequence_transform=lambda x: x + 1,
+        cell_type_transform=lambda x: x + 20,
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        seen_cell_type_ids = set()
+        for batch in dataloader:
+            assert batch[0].shape == (2, 4, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 2).all()
+            assert (batch[0].min(dim=1).values == 0).all()
+            assert (batch[0].sum(dim=1) == 2).all()
+            cell_type_ids = set(batch[1].tolist())
+            assert cell_type_ids.difference([21, 22, 30]) == set()
+            seen_cell_type_ids.update(cell_type_ids)
+        assert seen_cell_type_ids == set([21, 22, 30])
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_onehot_transforms():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="onehot",
+        sequence_transform=lambda x: x + 1,
+        cell_type_transform=lambda x: x + 20,
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        seen_cell_type_ids = set()
+        for batch in dataloader:
+            assert batch[0].shape == (2, 4, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 2).all()
+            assert (batch[0].min(dim=1).values == 1).all()
+            assert (batch[0].sum(dim=1) == 5).all()
+            cell_type_ids = set(batch[1].tolist())
+            assert cell_type_ids.difference([21, 22, 30]) == set()
+            seen_cell_type_ids.update(cell_type_ids)
+        assert seen_cell_type_ids == set([21, 22, 30])
+
+    # remove dummy data
+    os.remove(dummy_data_path)
+
+def test_ordinal_transforms():
+    # prepare dummy data
+    dummy_data_path = "_tmp_seq_dataloader_data.csv"
+    prepare_dummy_data(dummy_data_path)
+
+    # prepare data module
+    datamodule = SequenceDataModule(
+        train_path=dummy_data_path,
+        val_path=dummy_data_path,
+        test_path=dummy_data_path,
+        sequence_length=12,
+        sequence_encoding="ordinal",
+        sequence_transform=lambda x: x + 1,
+        cell_type_transform=lambda x: x + 20,
+        batch_size=2,
+        num_workers=1,
+    )
+    datamodule.setup()
+
+    # data checks
+    assert len(datamodule.train_data) == 4
+    assert len(datamodule.val_data) == 4
+    assert len(datamodule.test_data) == 4
+    for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
+        seen_cell_type_ids = set()
+        for batch in dataloader:
+            assert batch[0].shape == (2, 12)
+            assert batch[1].shape == (2,)
+            assert (batch[0].max(dim=1).values == 4).all()
+            assert (batch[0].min(dim=1).values == 1).all()
+            assert set(batch[0].tolist()[0]) == set([1, 2, 3, 4])
+            cell_type_ids = set(batch[1].tolist())
+            assert cell_type_ids.difference([21, 22, 30]) == set()
+            seen_cell_type_ids.update(cell_type_ids)
+        assert seen_cell_type_ids == set([21, 22, 30])
+
+    # remove dummy data
+    os.remove(dummy_data_path)

--- a/tests/data/test_sequence_dataloader.py
+++ b/tests/data/test_sequence_dataloader.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+import torch
 from src.data.sequence_dataloader import SequenceDataModule
 
 
@@ -85,16 +86,24 @@ def test_train_val_test_data_split():
     seen_nucleotide_idxs = set()
     for dl_idx, dataloader in enumerate([datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]):
         dataloader_iter = iter(dataloader)
+
         # first batch
         batch = next(dataloader_iter)
+        assert len(batch) == 2
+        assert isinstance(batch[0], torch.Tensor)
+        assert isinstance(batch[1], torch.Tensor)
         assert batch[0].shape == (3, 4, 10)
         assert batch[1].shape == (3,)
         uniq_nucleotides = batch[0].max(dim=1).indices.unique().tolist()
         seen_nucleotide_idxs.update(uniq_nucleotides)
         assert len(uniq_nucleotides) == 1
         assert (batch[1] == dl_idx).all()
+
         # second batch
         batch = next(dataloader_iter)
+        assert len(batch) == 2
+        assert isinstance(batch[0], torch.Tensor)
+        assert isinstance(batch[1], torch.Tensor)
         assert batch[0].shape == (1, 4, 10)
         assert batch[1].shape == (1,)
         assert batch[0].max(dim=1).indices.unique().tolist() == uniq_nucleotides
@@ -127,6 +136,9 @@ def test_polar_encoding():
     assert len(datamodule.test_data) == 4
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 4, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 1).all()
@@ -159,6 +171,9 @@ def test_onehot_encoding():
     assert len(datamodule.test_data) == 4
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 4, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 1).all()
@@ -191,6 +206,9 @@ def test_ordinal_encoding():
     assert len(datamodule.test_data) == 4
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 3).all()
@@ -226,6 +244,9 @@ def test_polar_transforms():
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         seen_cell_type_ids = set()
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 4, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 2).all()
@@ -265,6 +286,9 @@ def test_onehot_transforms():
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         seen_cell_type_ids = set()
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 4, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 2).all()
@@ -304,6 +328,9 @@ def test_ordinal_transforms():
     for dataloader in [datamodule.train_dataloader(), datamodule.val_dataloader(), datamodule.test_dataloader()]:
         seen_cell_type_ids = set()
         for batch in dataloader:
+            assert len(batch) == 2
+            assert isinstance(batch[0], torch.Tensor)
+            assert isinstance(batch[1], torch.Tensor)
             assert batch[0].shape == (2, 12)
             assert batch[1].shape == (2,)
             assert (batch[0].max(dim=1).values == 4).all()


### PR DESCRIPTION
* Fixed a small issue with dataset `data_path` parameter (previously passed in `**kwargs`)
* Added tests for the `SequenceDataModule` (sequence dataloader) - can be directly used with pytest (hence should work with [this pull request](https://github.com/pinellolab/DNA-Diffusion/pull/31))
...As I was at it, I also included additional sequence encoding methods - previously only _analog bits_ (_polar_) encoding; now I also added the standard onehot and ordinal encoding options.