### PR TITLE
Adding enformer oracle extraction

### DIFF
--- a/dna-diffusion/metrics/gene_expression/enformer/enformer_lucidrains_pytorch/aux_functions.py
+++ b/dna-diffusion/metrics/gene_expression/enformer/enformer_lucidrains_pytorch/aux_functions.py
@@ -1,0 +1,62 @@
+import torch
+import numpy as np 
+from Bio import SeqIO
+
+arr = np.asarray
+
+
+nuc2ind = {
+    'A' : 0,
+    'C' : 1,
+    'G' : 2,
+    'T' : 3,
+    'N' : 4,
+}
+
+def seq_to_index(seq):
+    """
+    From seq to index
+    """
+    seq = arr([nuc2ind[x] for x in seq])
+    return torch.Tensor(seq.astype(int)).to(torch.int64)
+
+
+
+def get_coords_from_bedfile(bedfile):
+    """
+    Returns chrom, s, e
+    """
+    bed_df = bedfile.to_dataframe()
+    chrom, s, e = bed_df['chrom'], bed_df['start'], bed_df['end']
+    chrom = chrom.astype(str)
+    s, e = s.astype(int), e.astype(int)
+    return chrom.values, s.values, e.values
+
+
+def add_chrom_to_chromlist(chromlist):
+    """
+    Add 'chr' from all in chromlist where it exists
+    """
+    return ['chr' + x if 'chr' not in x else x for x in chromlist]
+
+def del_chrom_from_chromlist(chromlist):
+    """
+    Remove 'chr' from all in chromlist where it exists
+    """
+    return [x if 'chr' not in x else x[3:] for x in chromlist]
+
+
+def get_fa_seq(records, row):
+    """
+    Get sequence from SeqIO file
+    """
+    records_have_chr = all(['chr' == x[:3] for x in records.keys()])
+    sequencelist = []
+    chrom, s, e = row[:3]
+    s, e = map(int, [s, e])
+    if records_have_chr:
+        chrom = add_chrom_to_chromlist(chrom)[0]
+    else:
+        chrom = del_chrom_from_chromlist(chrom)[0]
+    seq_as_str = str(records[chrom][s : e].seq).upper()
+    return seq_as_str, f'{chrom}:{s}-{e}'

--- a/dna-diffusion/metrics/gene_expression/enformer/enformer_lucidrains_pytorch/get_enformer_predictions.py
+++ b/dna-diffusion/metrics/gene_expression/enformer/enformer_lucidrains_pytorch/get_enformer_predictions.py
@@ -1,0 +1,65 @@
+import torch
+from Bio import SeqIO
+import pybedtools as pbt
+from aux_functions import *
+from enformer_pytorch import seq_indices_to_one_hot
+
+def get_enformer_pred(enformer, bedfile, expand_by = 0, gpath=None, bin_size=128, enformer_seqlength = 196_608, 
+                                fapath=None, enformer_keys = {}, records=None):
+    """ 
+    Takes a bed file and returns enformer predictions
+    """
+    assert type(bedfile) == pbt.bedtool.BedTool
+    # If we want to add flanking regions
+    if expand_by > 0:
+        bedfile = bedfile.slop(b = expand_by, g = gpath)
+    # Get coordinates
+    bedfile_chrom, s, e = get_coords_from_bedfile(bedfile)
+    assert ((e - s) == enformer_seqlength).all() # Make sure seqlength equals enformer prediction length
+    
+    if records is None:
+        records = SeqIO.to_dict(SeqIO.parse(open(fapath), 'fasta'))    
+    
+    resdict = {}
+    for row in bedfile:
+        seq, genomic_region = get_fa_seq(records, row)
+        indices = seq_to_index(seq)
+        one_hot = seq_indices_to_one_hot(indices).cuda()
+        with torch.no_grad():
+            output = enformer(one_hot)
+            
+        full_output = []
+        output_descriptions = []
+        for organism in ['mouse', 'human']:
+            organism_inds = enformer_keys.get(organism)
+            if organism_inds is None:
+                continue
+            else:
+                organism_output = output[organism][:, organism_inds].cpu()
+                full_output.append(organism_output)
+                output_descriptions += [f'{organism}_{i}' for i in organism_inds]
+        assert len(full_output) > 0
+        full_torch_output = torch.cat(full_output, axis=1)
+        resdict[genomic_region] = full_torch_output
+    return resdict, output_descriptions
+
+
+
+### Minimally reproducing example:
+
+import torch
+from enformer_pytorch import Enformer
+from Bio import SeqIO
+records = SeqIO.to_dict(SeqIO.parse(open('mm10/mm10.fa'), 'fasta'))
+bedfile = pbt.BedTool([['1', 10_000_000, 10_000_000+196608]])
+enformer_keys = {
+    'human' : [0, 1, 2],
+    'mouse' : [100]
+}
+
+enformer = Enformer.from_hparams(
+    dim = 1536,
+    depth = 1,
+    heads = 8,
+)
+results_dict, output_descriptions = get_enformer_pred(enformer.cuda(), bedfile, enformer_keys = enformer_keys, records = records)


### PR DESCRIPTION
Extract predictions from enformer.
Note: 320*128 basepairs are cropped from each side of the bed file during enformer predictions