### PR TITLE
Initialize model with Hydra

### DIFF
--- a/src/configs/dataset/sequence.yaml
+++ b/src/configs/dataset/sequence.yaml
@@ -1,5 +1,5 @@
 train_dl:
-  _target_: src.data.sequence_dataloader.SequenceDataModule
+  _target_: data.sequence_dataloader.SequenceDataModule
   train_path: # add training dataset path
   batch_size: 32
   num_workers: 4
@@ -7,7 +7,7 @@ train_dl:
   #  _target_: # directly reference transforms -> torchvision.transforms.ToTensor
 
 val_dl:
-  _target_: src.data.sequence_dataloader.SequenceDataModule
+  _target_: data.sequence_dataloader.SequenceDataModule
   val_path: # add validation dataset path
   batch_size: 32
   num_workers: 4

--- a/src/configs/model/unet_conditional.yaml
+++ b/src/configs/model/unet_conditional.yaml
@@ -1,29 +1,29 @@
-model:
-  _target_: src.models.diffusion.ddpm
-  params:
-    beta_end: 0.05
-    schedule: linear
-    timestep: 200
-    is_conditional: True
-    criterion: utils.metrics.MetricName
-    use_ema: True
-    lr_warmup: 5000
-    lr_scheduler_config:
-      _target_: torch.optim.lr_scheduler.MultiStepLR
-      params:
-        milestones: [5, 10, 20]
-        gamma: 0.1
-    unet_config:
-      _target_: models.networks.unet_lucas
-      params:
-        dim: 200
-        init_dim: None
-        dim_mult: [1, 2, 4]
-        channels: 1
-        resnet_block_groups: 8
-        learned_sinusoidal_dim: 16
+_target_: models.diffusion.ddpm.DDPM
+beta_end: 0.05
+image_size: 200
+logdir: logs/unet_conditional
+use_fp16: True
+noise_schedule: linear
+timesteps: 200
+is_conditional: True
+criterion: utils.metrics.MetricName
+use_ema: True
+lr_warmup: 5000
+lr_scheduler_config:
+  _partial_: true # fully initialized manually
+  _target_: torch.optim.lr_scheduler.MultiStepLR
+  milestones: [5, 10, 20]
+  gamma: 0.1
+unet:
+  _target_: models.networks.unet_lucas.UNetLucas
+  dim: 200
+  init_dim: 8
+  dim_mults: [1, 2, 4]
+  channels: 1
+  resnet_block_groups: 8
+  learned_sinusoidal_dim: 16
 
-    optimizer_config:
-      target: torch.optim.Adam
-      params:
-        lr: 1e-4
+optimizer_config:
+  _partial_: true # fully initialized manually
+  _target_: torch.optim.Adam
+  lr: 1e-4

--- a/src/models/networks/unet_lucas.py
+++ b/src/models/networks/unet_lucas.py
@@ -1,12 +1,12 @@
 import math
 from functools import partial
 from einops import rearrange
-from typing import Optional, List, Callable
+from typing import Optional, List, Callable, Union
 
 import torch
 from torch import nn, einsum
 
-from utils.misc import default
+from utils.misc import default, exists
 from utils.network import l2norm
 
 
@@ -189,7 +189,7 @@ class UNetLucas(nn.Module):
         self,
         dim: int,
         init_dim: int = None,
-        dim_mults: Optional[int, list] = (1, 2, 4),
+        dim_mults: Union[int, List[int]] = (1, 2, 4),
         channels: int = 1,
         resnet_block_groups: int = 8,
         learned_sinusoidal_dim: int = 18,

--- a/src/utils/ema.py
+++ b/src/utils/ema.py
@@ -1,12 +1,13 @@
 class EMA:
-    def __init__(self, beta):
+    def __init__(self, model, beta):
         super().__init__()
+        self.ma_model = model
         self.beta = beta
         self.step = 0
 
-    def update_model_average(self, ma_model, current_model):
+    def update_model_average(self, current_model):
         for current_params, ma_params in zip(
-            current_model.parameters(), ma_model.parameters()
+            current_model.parameters(), self.ma_model.parameters()
         ):
             old_weight, up_weight = ma_params.data, current_params.data
             ma_params.data = self.update_average(old_weight, up_weight)
@@ -16,13 +17,13 @@ class EMA:
             return new
         return old * self.beta + (1 - self.beta) * new
 
-    def step_ema(self, ema_model, model, step_start_ema=2000):
+    def step_ema(self, model, step_start_ema=2000):
         if self.step < step_start_ema:
-            self.reset_parameters(ema_model, model)
+            self.reset_parameters(self.model, model)
             self.step += 1
             return
-        self.update_model_average(ema_model, model)
+        self.update_model_average(self.ma_model, model)
         self.step += 1
 
-    def reset_parameters(self, ema_model, model):
-        ema_model.load_state_dict(model.state_dict())
+    def reset_parameters(self, model):
+        self.ma_model.load_state_dict(model.state_dict())


### PR DESCRIPTION
Model initialization is now _almost_ fully in the hands of Hydra. Instead of calling separately `instantiate_from_config(config, **kwargs)`, Hydra's `initialize(cfg.model)` does most of the work.

Optimizer and lr scheduler still needs to be initialized manually - see `DiffusionModel.configure_optimizers()`. Do we want to call this during the initialization of the DiffusionModel?

Initialization with Hydra can be tested by running `src/train.py`, commenting out everything else in the `train(cfg: DictConfig)` function except the block with `model = instantiate(cfg.model)`. For example:
```python
model = instantiate(cfg.model)
print(model)
print(model.configure_optimizers())
```

Additionally, I needed to do a small change to the `src/utils/ema/EMA` 's interface to make it compatible with the diffusion model.