### PR TITLE
Changes all import lightning to import pytorch_lightning

### DIFF
--- a/src/dnadiffusion/callbacks/ema.py
+++ b/src/dnadiffusion/callbacks/ema.py
@@ -1,14 +1,12 @@
-from typing import Any
-
-import lightning as L
+import pytorch_lightning as pl
 import torch
-from lightning.pytorch.utilities import rank_zero_only
+from pytorch_lightning.utilities import rank_zero_only
 
 # Check this link
 # https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/common/callbacks/ema.py
 
 
-class EMA(L.Callback):
+class EMA(pl.Callback):
     def init(
         self,
         beta: float = 0.995,
@@ -19,15 +17,15 @@ class EMA(L.Callback):
 
     def on_train_batch_end(
         self,
-        trainer: L.Trainer,
-        pl_module: L.LightningModule,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
     ) -> None:
         self.step_ema(pl_module.ema_model, pl_module.model)
 
     def update_model_average(
         self,
-        ma_model: L.LightningModule,
-        current_model: L.LightningModule,
+        ma_model: pl.LightningModule,
+        current_model: pl.LightningModule,
     ) -> None:
         for current_params, ma_params in zip(current_model.parameters(), ma_model.parameters()):
             old_weight, up_weight = ma_params.data, current_params.data
@@ -41,8 +39,8 @@ class EMA(L.Callback):
 
     def step_ema(
         self,
-        ema_model: L.LightningModule,
-        model: L.LightningModule,
+        ema_model: pl.LightningModule,
+        model: pl.LightningModule,
     ) -> None:
         if self.step < self.step_start_ema:
             self.reset_parameters(ema_model, model)

--- a/src/dnadiffusion/callbacks/sampling.py
+++ b/src/dnadiffusion/callbacks/sampling.py
@@ -1,6 +1,5 @@
-import lightning as L
-import pandas as pd
-from lightning.pytorch.utilities import rank_zero_only
+import pytorch_lightning as pl
+from pytorch_lightning.utilities import rank_zero_only
 
 from dnadiffusion.metrics.sampling_metrics import (
     compare_motif_list,
@@ -9,10 +8,10 @@ from dnadiffusion.metrics.sampling_metrics import (
 )
 
 
-class Sample(L.Callback):
+class Sample(pl.Callback):
     def __init__(
         self,
-        data_module: L.LightningDataModule,
+        data_module: pl.LightningDataModule,
         image_size: int,
         num_sampling_to_compare_cells: int,
     ) -> None:
@@ -29,7 +28,7 @@ class Sample(L.Callback):
         self.numeric_to_tag = self.data_module.numeric_to_tag
 
     @rank_zero_only
-    def on_train_epoch_end(self, trainer: L.Trainer, L_module: L.LightningModule):
+    def on_train_epoch_end(self, trainer: pl.Trainer, L_module: pl.LightningModule):
         if (trainer.current_epoch + 1) % 15 == 0:
             L_module.eval()
             additional_variables = {

--- a/src/dnadiffusion/configs.py
+++ b/src/dnadiffusion/configs.py
@@ -1,10 +1,10 @@
-import lightning as L
+import pytorch_lightning as pl
 import torch
 import torchvision.transforms as T
 from hydra.core.config_store import ConfigStore
 from hydra_zen import MISSING, builds, make_custom_builds_fn
-from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.loggers import WandbLogger
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.loggers.wandb import WandbLogger 
 
 from dnadiffusion.callbacks.sampling import Sample
 from dnadiffusion.data.dataloader import LoadingDataModule
@@ -84,7 +84,7 @@ checkpoint = builds(
 
 # Lightning Trainer
 LightningTrainer = builds(
-    L.Trainer,
+    pl.Trainer,
     accelerator="cuda",
     strategy="ddp_find_unused_parameters_true",
     num_nodes=1,

--- a/src/dnadiffusion/data/dataloader.py
+++ b/src/dnadiffusion/data/dataloader.py
@@ -3,13 +3,13 @@ import pickle
 import random
 from typing import Any, Dict, List, Optional, Tuple
 
-import lightning as L
+import pytorch_lightning as pl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
 import torchvision.transforms as T
-from lightning.pytorch.utilities import rank_zero_only
+from pytorch_lightning.utilities import rank_zero_only
 from torch.utils.data import DataLoader, Dataset
 
 from dnadiffusion.utils.utils import one_hot_encode
@@ -173,7 +173,7 @@ class SequenceDataset(Dataset):
         return x, y
 
 
-class LoadingDataModule(L.LightningDataModule):
+class LoadingDataModule(pl.LightningDataModule):
     def __init__(
         self,
         input_csv: str,

--- a/src/dnadiffusion/models/training_modules.py
+++ b/src/dnadiffusion/models/training_modules.py
@@ -1,6 +1,6 @@
 import copy
 
-import lightning as L
+import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 from torch.optim import Adam
@@ -11,7 +11,7 @@ from dnadiffusion.utils.ema import EMA
 from dnadiffusion.utils.scheduler import linear_beta_schedule
 
 
-class UnetDiffusion(L.LightningModule):
+class UnetDiffusion(pl.LightningModule):
     def __init__(
         self,
         model: Unet,

--- a/train.py
+++ b/train.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import hydra
-import lightning as L
 from hydra.core.config_store import ConfigStore
 from hydra_zen import MISSING, instantiate, make_config
 from omegaconf import DictConfig


### PR DESCRIPTION
* Resolves #126 
* When lightning 2.0 first released, the cluster environment had it installed using pypi where the package was named lightning instead of pytorch_lightning
* Package name is now pytorch_lightning across pypi and conda-forge