### PR TITLE
Fix device allocation in sample.py / simplify sequence generation

### DIFF
--- a/environments/conda/environment.yml
+++ b/environments/conda/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     # - cudatoolkit=11.8 # conda-forge < pytorch + nvidia
     # - nccl # conda-forge < pytorch + nvidia
     - python=3.10
-    - pytorch=2.0.0
+    - pytorch
     - pytorch-cuda=11.8
     - torchvision
     - accelerate
@@ -21,8 +21,6 @@ dependencies:
     - einops
     - wandb
     - genomepy
-    - pytorch-lightning
-    - hydra-core
     - sourmash-minimal
     - pip
     - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "click",
-  "torch==2.0.0",
+  "torch>=2.0.0",
   "torchvision",
   "accelerate",
   "matplotlib",
@@ -179,8 +179,6 @@ dependencies = [
   "einops",
   "wandb",
   "genomepy",
-  "pytorch-lightning",
-  "hydra-core",
   "sourmash",
   "gimmemotifs",
   "memory-efficient-attention-pytorch",

--- a/sample.py
+++ b/sample.py
@@ -67,9 +67,11 @@ def sample(model_path: str, num_samples: int = 1000):
             specific_group=True,
             group_number=i,
             cond_weight_to_metric=1,
-            save_timestep_dataframe=True,
+            save_timesteps=False,
+            save_dataframe=True,
         )
 
 
 if __name__ == "__main__":
-    sample("../../../Documents/epoch_8500_model_48k_sequences_per_group_K562_hESCT0_HepG2_GM12878_12k.pt", 10)
+    # Uncomment and add checkpoint path to create samples
+    #sample()

--- a/sample.py
+++ b/sample.py
@@ -73,5 +73,4 @@ def sample(model_path: str, num_samples: int = 1000):
 
 
 if __name__ == "__main__":
-    # Uncomment and add checkpoint path to create samples
-    #sample()
+    sample()

--- a/src/dnadiffusion/metrics/metrics.py
+++ b/src/dnadiffusion/metrics/metrics.py
@@ -5,8 +5,8 @@ import seaborn as sns
 from scipy.special import rel_entr
 from tqdm import tqdm
 
-from dnadiffusion.utils.utils import one_hot_encode
 from dnadiffusion.utils.sample_util import create_sample
+from dnadiffusion.utils.utils import one_hot_encode
 
 
 def compare_motif_list(df_motifs_a: pd.DataFrame, df_motifs_b: pd.DataFrame):


### PR DESCRIPTION
* Resolves #159 
* Adds accelerate to sample.py for easy device allocation during sample generation
* Adds save_timesteps and save_dataframe flags to more easily specify how many samples to generate
* Removes some old depedencies from environment.yml and pyproject.toml that are currently unused and updates them to allow for torch>=2.0.0
